### PR TITLE
Add version management

### DIFF
--- a/configure
+++ b/configure
@@ -1,5 +1,27 @@
 #!/usr/bin/env python2
 
+#
+# Copyright (C) 2013-2019 Christoph Sommer <sommer@ccs-labs.org>
+#
+# Documentation for these modules is at http://veins.car2x.org/
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+
 """
 Creates Makefile(s) for building this project.
 """
@@ -28,11 +50,23 @@ run_imgs = [os.path.join('images')]
 
 
 # Add flags for Veins
-check_fname = os.path.join(args.veins, 'src/veins/package.ned')
-expect_version = '5'
-if not os.path.isfile(check_fname):
-    error('Could not find Veins (by looking for %s). Check the path to Veins (--with-veins=... option) and the Veins version (should be version %s)' % (check_fname, expect_version))
-    sys.exit(1)
+if True:
+    fname = os.path.join(args.veins, 'print-veins-version')
+    expect_version = ['5.0-alpha2']
+    try:
+        print 'Running "%s" to determine Veins version.' % fname
+        version = subprocess.check_output(['env', fname]).strip()
+        if not version in expect_version:
+            print ''
+            print '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
+            warning('Unsupported Veins Version. Expecting %s, found "%s"' % (' or '.join(expect_version), version))
+            print '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
+            print ''
+        else:
+            print 'Found Veins version "%s". Okay.' % version
+    except subprocess.CalledProcessError as e:
+        error('Could not determine Veins Version (by running %s): %s. Check the path to Veins (--with-veins=... option) and the Veins version (should be version %s)' % (fname, e, ' or '.join(expect_version)))
+        sys.exit(1)
 
 veins_header_dirs = [os.path.join(os.path.relpath(args.veins, 'src'), 'src')]
 veins_includes = ['-I' + s for s in veins_header_dirs]

--- a/print-plexe-version
+++ b/print-plexe-version
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2019 Christoph Sommer <sommer@ccs-labs.org>
+#
+# Documentation for these modules is at http://veins.car2x.org/
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+
+import argparse
+import os
+import sys
+
+parser = argparse.ArgumentParser(description='Print version number of plexe (e.g., "4.0") or a component thereof.', epilog='Not all combinations of switches are supported.')
+parser.add_argument('-M', '--major', action='store_true', help='print only the major version')
+parser.add_argument('-m', '--minor', action='store_true', help='print only the minor version')
+parser.add_argument('-p', '--patch', action='store_true', help='print only the patch level')
+parser.add_argument('-a', '--alpha', action='store_true', help='print only the alpha stage')
+args = parser.parse_args()
+
+header_file_name = os.path.join(os.path.dirname(__file__), 'src', 'plexe', 'plexe.h')
+
+major = None
+minor = None
+patch = None
+alpha = None
+
+with open(header_file_name) as f:
+    for line in f:
+        line = line.strip()
+        if line.startswith('#define PLEXE_VERSION_MAJOR '):
+            major = int(line[28:])
+        if line.startswith('#define PLEXE_VERSION_MINOR '):
+            minor = int(line[28:])
+        if line.startswith('#define PLEXE_VERSION_PATCH '):
+            patch = int(line[28:])
+        if line.startswith('#define PLEXE_VERSION_ALPHA '):
+            alpha = int(line[28:])
+
+if None in (major, minor, patch, alpha):
+    print('Could not parse "{}". Aborting.'.format(header_file_name), file=sys.stderr)
+    sys.exit(1)
+
+version_string = ''
+if (args.major, args.minor, args.patch, args.alpha) == (True, False, False, False):
+    version_string = "{}".format(major)
+elif (args.major, args.minor, args.patch, args.alpha) == (True, True, False, False):
+    version_string = "{}.{}".format(major, minor)
+elif (args.major, args.minor, args.patch, args.alpha) == (False, True, False, False):
+    version_string = "{}".format(minor)
+elif (args.major, args.minor, args.patch, args.alpha) == (False, False, True, False):
+    version_string = "{}".format(patch)
+elif (args.major, args.minor, args.patch, args.alpha) == (False, False, False, True):
+    version_string = "{}".format(alpha)
+elif (args.major, args.minor, args.patch, args.alpha) == (False, False, False, False):
+    version_string = "{}.{}".format(major, minor)
+    if patch > 0:
+        version_string += ".{}".format(patch)
+    if alpha > 0:
+        version_string += "-alpha{}".format(alpha)
+else:
+    print('Invalid version format requested', file=sys.stderr)
+    sys.exit(1)
+
+print(version_string)

--- a/src/plexe/plexe.h
+++ b/src/plexe/plexe.h
@@ -1,3 +1,36 @@
+//
+// Copyright (C) 2012-2019 Michele Segata <segata@ccs-labs.org>
+//
+// Documentation for these modules is at http://veins.car2x.org/
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+
 #pragma once
 
-#include <veins/veins.h>
+#include "veins/veins.h"
+
+// Version number of last release ("major.minor.patch") or an alpha version, if nonzero
+#define PLEXE_VERSION_MAJOR 3
+#define PLEXE_VERSION_MINOR 0
+#define PLEXE_VERSION_PATCH 0
+#define PLEXE_VERSION_ALPHA 1
+
+// Explicitly check Veins version number
+#if !(VEINS_VERSION_MAJOR == 5 && VEINS_VERSION_MINOR >= 0)
+#error Veins version 5.0 or compatible required
+#endif


### PR DESCRIPTION
This copies the following code for version management from Veins for both export...

- `plexe/plexe.h` now contains preprocessor defines like `#define PLEXE_VERSION_MAJOR 3`
- a new script, `print-plexe-version` uses these defines to print the current version to stdout

...and import:

- `configure` uses the equivalent in Veins to warn for non-compatible versions (here: other than `5.0-alpha2`)
- `plexe/plexe.h` fails unless `VEINS_VERSION_MAJOR == 5 && VEINS_VERSION_MINOR >= 0`

