### PR TITLE
Adding in CommandInterface the possibility to retrieve distance of neighbors

### DIFF
--- a/src/plexe/mobility/CommandInterface.cc
+++ b/src/plexe/mobility/CommandInterface.cc
@@ -84,7 +84,7 @@ void CommandInterface::Vehicle::changeLane(int lane, double duration)
 
 std::vector<CommandInterface::Vehicle::neighbor> CommandInterface::Vehicle::getNeighbors(uint8_t lateralDirection, uint8_t longitudinalDirection, uint8_t blocking)
 {
-    TraCIBuffer response = cifc->connection->query(CMD_GET_VEHICLE_VARIABLE, TraCIBuffer() << static_cast<uint8_t>(CMD_NEIGHBORING_VEHICLES)
+    TraCIBuffer response = cifc->connection->query(CMD_GET_VEHICLE_VARIABLE, TraCIBuffer() << static_cast<uint8_t>(VAR_NEIGHBORS)
             << nodeId
             << static_cast<uint8_t>(TYPE_UBYTE)
             << static_cast<uint8_t>(blocking<<2 | longitudinalDirection<<1 | lateralDirection));
@@ -96,7 +96,7 @@ std::vector<CommandInterface::Vehicle::neighbor> CommandInterface::Vehicle::getN
     ASSERT(responseId == RESPONSE_GET_VEHICLE_VARIABLE);
     uint8_t variable;
     response >> variable;
-    ASSERT(variable == CMD_NEIGHBORING_VEHICLES);
+    ASSERT(variable == VAR_NEIGHBORS);
     std::string id;
     response >> id;
     uint8_t type;

--- a/src/plexe/mobility/CommandInterface.h
+++ b/src/plexe/mobility/CommandInterface.h
@@ -39,6 +39,8 @@ class CommandInterface : public veins::HasLogProxy {
 public:
     class Vehicle {
     public:
+        typedef std::tuple<std::string, double> neighbor;
+
         Vehicle(CommandInterface* cifc, const std::string& nodeId)
             : cifc(cifc)
             , nodeId(nodeId)
@@ -48,6 +50,11 @@ public:
         void setLaneChangeMode(int mode);
         void getLaneChangeState(int direction, int& state1, int& state2);
         void changeLane(int lane, double duration);
+        /**
+         * Get neighbors (i.e. a pair <name, distance>) of the vehicle.
+         */
+        std::vector<neighbor> getNeighbors(uint8_t lateralDirection, uint8_t longitudinalDirection, uint8_t blocking = 0);
+
         /**
          * Sets the data about the leader of the platoon. This data is usually received
          * by means of wireless communications

--- a/src/plexe/mobility/CommandInterface.h
+++ b/src/plexe/mobility/CommandInterface.h
@@ -35,6 +35,10 @@ class TraCIConnection;
 namespace plexe {
 namespace traci {
 
+#ifndef VAR_NEIGHBORS
+#define VAR_NEIGHBORS 0xbf
+#endif
+
 class CommandInterface : public veins::HasLogProxy {
 public:
     class Vehicle {


### PR DESCRIPTION
Hi,
another student and me (both of UNIBS) added the possibility to retrieve the distance of neighbors of a vehicle.
This was necessary to verify the possibility to change lane securely, that is checking the distance of other vehicles before beginning the change of the lane of the whole platoon. Furthermore, this allows us to make different test to check which distance can be marked as secure.

:warning: The "CMD_NEIGHBORING_VEHICLES" must be inserted in veins. Its value should be 0xBF.
An alternative could be to hardcode this in plexe, but i think it's not a good idea.

I put a minimal doc, that is similar to the doc in the code of plexe. I guess it would be better to explain in the doc the value that lateralDirection and longitudinalDirection must have (but is already explained in SUMO). We can discuss about it before accepting the pull request.